### PR TITLE
Use npm trusted publishing for releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -21,6 +22,8 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Install Dependencies
         run: pnpm install -f
 
@@ -36,4 +39,3 @@ jobs:
           title: "chore: release eslint-plugin-module-interop"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use npm trusted publishing for releases instead of the long-lived `NPM_TOKEN`. The release workflow now requests an OIDC identity token and runs on Node.js 24 so its npm version supports the exchange. `GITHUB_TOKEN` remains available to Changesets for release pull requests and GitHub releases.

Before merging, configure the npm package's GitHub Actions trusted publisher for `ota-meshi/eslint-plugin-module-interop` with workflow `Release.yml` and allow `npm publish`.
