### PR TITLE
fix: delimit env-cmd arguments in release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "ts": "node --import=tsx",
     "mocha": "pnpm run ts ./node_modules/mocha/bin/mocha.js",
     "preversion": "pnpm test && git add .",
-    "version": "env-cmd -e version pnpm run update && git add .",
-    "version:ci": "env-cmd -e version-ci pnpm run update && changeset version",
+    "version": "env-cmd -e version -- pnpm run update && git add .",
+    "version:ci": "env-cmd -e version-ci -- pnpm run update && changeset version",
     "prerelease": "pnpm run build",
     "release": "changeset publish"
   },


### PR DESCRIPTION
env-cmd v11 treats values after its variadic `-e` option as environment names until a `--` delimiter. With a pending changeset, `changesets/action` invokes `version:ci`, so the missing delimiter makes `update` look like an environment name and stops the Release workflow.

Add the required delimiter to both version scripts. This lets env-cmd launch `pnpm run update` while preserving the existing follow-up steps for local versioning and Changesets.
