### PR TITLE
fix: restore Changesets release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to pnpm
         id: changesets
-        uses: changesets/action@v2.1.0
+        uses: changesets/action@v1
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
           version: pnpm run version:ci

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
     {
       "matchManagers": ["github-actions", "devcontainer"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["changesets/action"],
+      "allowedVersions": "<2"
     }
   ]
 }


### PR DESCRIPTION
`changesets/action@v2` requires Changesets CLI v3 and renamed action inputs, but this repository still uses CLI v2 and the v1 input contract. The [failing Release run](https://github.com/ota-meshi/eslint-plugin-module-interop/actions/runs/31696585666) therefore exits before it can create a release pull request or publish a package.

Restore the action's v1 compatibility tag and constrain only `changesets/action` to versions below v2 in Renovate. This keeps other GitHub Actions updates unchanged while preventing the incompatible major update from being automatically merged again.
