### PR TITLE
fix: migrate release workflow to Changesets v2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,13 +29,11 @@ jobs:
 
       - name: Create Release Pull Request or Publish to pnpm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2.1.0
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: pnpm run version:ci
+          version-script: pnpm run version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm run release
-          commit: "chore: release eslint-plugin-module-interop"
-          title: "chore: release eslint-plugin-module-interop"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: pnpm run release
+          commit-message: "chore: release eslint-plugin-module-interop"
+          pr-title: "chore: release eslint-plugin-module-interop"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.28.1",
+    "@changesets/cli": "^3.0.0",
     "@changesets/get-release-plan": "^4.0.8",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "@shikijs/vitepress-twoslash": "^3.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -13,11 +13,6 @@
     {
       "matchManagers": ["github-actions", "devcontainer"],
       "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["changesets/action"],
-      "allowedVersions": "<2"
     }
   ]
 }


### PR DESCRIPTION
`changesets/action@v2` rejects both the repository's v1 input names and Changesets CLI v2. This caused the [Release workflow](https://github.com/ota-meshi/eslint-plugin-module-interop/actions/runs/31696585666) to stop before creating a version pull request or publishing packages.

Migrate the workflow to the v2 input names and Changesets CLI v3, which matches the Release job's Node 24 and pnpm 10 environment. Remove the v1-only Renovate constraint so dependency updates remain aligned with the selected action major.
