### PR TITLE
chore: replace pnpm with npm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "pnpm install",
+  "postCreateCommand": "npm install",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -25,13 +25,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
+        with:
+          package-manager-cache: false
       - name: Install Packages
-        run: pnpm install -f
+        run: npm install
       - name: Build
         run: |+
-          pnpm run docs:build
+          npm run docs:build
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
+        with:
+          package-manager-cache: false
       - name: Install Packages
-        run: pnpm install -f
+        run: npm install
       - name: Lint
-        run: pnpm run lint
+        run: npm run lint
       - name: tsc
-        run: pnpm run tsc
+        run: npm run tsc
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -26,12 +27,12 @@ jobs:
         node-version: [18.x, 20.x, 21.x, 22.x]
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
       - name: Install Packages
-        run: pnpm install -f
+        run: npm install
       - name: Test
-        run: pnpm test
+        run: npm test

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -18,22 +18,21 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install Dependencies
-        run: pnpm install -f
+        run: npm install
 
-      - name: Create Release Pull Request or Publish to pnpm
+      - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v2.1.0
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version-script: pnpm run version:ci
+          version-script: npm run version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish-script: pnpm run release
+          publish-script: npm run release
           commit-message: "chore: release eslint-plugin-module-interop"
           pr-title: "chore: release eslint-plugin-module-interop"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,16 +10,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
       - name: Setup node
         uses: actions/setup-node@v7
+        with:
+          package-manager-cache: false
       - name: Install deps
-        run: pnpm install -f
-      - name: Update deps
-        run: pnpm update -D -f
+        run: npm install
       - name: Format
-        run: pnpm run eslint-fix
+        run: npm run eslint-fix
       - name: Commit
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install Packages
-        run: pnpm install
+        run: npm install
       - name: Build
-        run: pnpm run build
-      - run: pnpx pkg-pr-new publish --compact '.' --json output.json --comment=off
+        run: npm run build
+      - run: npx --yes pkg-pr-new publish --compact '.' --json output.json --comment=off
       - name: Add metadata to output
         uses: actions/github-script@v9
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
-.pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/package.json
+++ b/package.json
@@ -16,25 +16,25 @@
     "node": "^18.18.0||^20.9.0||>=21.1.0"
   },
   "scripts": {
-    "build": "pnpm run build:meta && pnpm run build:tsdown",
-    "build:meta": "pnpm run ts -- ./tools/update-meta.ts",
+    "build": "npm run build:meta && npm run build:tsdown",
+    "build:meta": "npm run ts -- ./tools/update-meta.ts",
     "build:tsdown": "tsdown",
     "lint": "eslint --config ./eslint.config.mjs .",
     "tsc": "tsc --project tsconfig.build.json",
     "eslint-fix": "eslint --config ./eslint.config.mjs . --fix",
-    "test": "pnpm run mocha -- \"tests/src/**/*.ts\" --reporter=dot --timeout=60000",
-    "cover": "c8 --reporter=lcov pnpm run test",
-    "test:update": "pnpm run mocha -- \"tests/src/**/*.ts\" --reporter=dot --update",
-    "update": "pnpm run ts -- ./tools/update.ts && pnpm run eslint-fix",
-    "new": "pnpm run ts -- ./tools/new-rule.ts",
+    "test": "npm run mocha -- \"tests/src/**/*.ts\" --reporter=dot --timeout=60000",
+    "cover": "c8 --reporter=lcov npm run test",
+    "test:update": "npm run mocha -- \"tests/src/**/*.ts\" --reporter=dot --update",
+    "update": "npm run ts -- ./tools/update.ts && npm run eslint-fix",
+    "new": "npm run ts -- ./tools/new-rule.ts",
     "docs:watch": "vitepress dev docs --open",
     "docs:build": "vitepress build docs",
     "ts": "node --import=@oxc-node/core/register",
-    "mocha": "pnpm run ts ./node_modules/mocha/bin/mocha.js",
-    "preversion": "pnpm test && git add .",
-    "version": "env-cmd -e version -- pnpm run update && git add .",
-    "version:ci": "env-cmd -e version-ci -- pnpm run update && changeset version",
-    "prerelease": "pnpm run build",
+    "mocha": "npm run ts -- ./node_modules/mocha/bin/mocha.js",
+    "preversion": "npm test && git add .",
+    "version": "env-cmd -e version -- npm run update && git add .",
+    "version:ci": "env-cmd -e version-ci -- npm run update && changeset version",
+    "prerelease": "npm run build",
     "release": "changeset publish"
   },
   "repository": {
@@ -123,5 +123,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "npm@10.9.9"
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "packageManager": "npm@10.9.9"
+  }
 }

--- a/src/rule-types.ts
+++ b/src/rule-types.ts
@@ -1,6 +1,6 @@
 // IMPORTANT!
 // This file has been automatically generated,
-// in order to update its content execute "pnpm run update"
+// in order to update its content execute "npm run update"
 
 /* eslint-disable */
 /* prettier-ignore */

--- a/tools/update-rule-types.ts
+++ b/tools/update-rule-types.ts
@@ -21,7 +21,7 @@ async function main() {
     path.join(dirname, "../src/rule-types.ts"),
     `// IMPORTANT!
 // This file has been automatically generated,
-// in order to update its content execute "pnpm run update"
+// in order to update its content execute "npm run update"
 
 ${ruleTypes}`,
   );


### PR DESCRIPTION
Replace pnpm with npm across package scripts, the development container, and every workflow that installs, builds, tests, formats, or publishes the package. This avoids the pnpm 11 migration conflicts with the existing Node.js test matrix and dependency build approval while keeping the package's supported runtimes unchanged.

The repository's existing lockfile-free dependency policy remains unchanged. Each workflow uses `npm install` and explicitly disables setup-node's automatic package-manager cache, which requires a lockfile; the format workflow no longer runs the redundant dev-dependency update after a fresh unlocked install.
